### PR TITLE
Integrate GTranslate float widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,17 +20,14 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
     
-    <script type="text/javascript">
-      function googleTranslateElementInit() {
-        new google.translate.TranslateElement({
-          pageLanguage: 'en',
-          includedLanguages: 'en,hr,de',
-          layout: google.translate.TranslateElement.InlineLayout.SIMPLE,
-          autoDisplay: false
-        }, 'google_translate_element');
-      }
+    <script>
+      window.gtranslateSettings = {
+        default_language: 'en',
+        languages: ['en', 'es', 'ar', 'pt', 'ru', 'ja', 'fr', 'de', 'vi', 'hr'],
+        wrapper_selector: '.gtranslate_wrapper'
+      };
     </script>
-    <script type="text/javascript" src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+    <script src="https://cdn.gtranslate.net/widgets/latest/float.js" defer></script>
   </head>
 
   <body>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -13,6 +13,7 @@ const Layout = ({ children }: LayoutProps) => {
         {children}
       </main>
       <Footer />
+      <div className="gtranslate_wrapper" />
     </div>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -75,3 +75,9 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* Hide Google Translate banner */
+.goog-te-banner-frame.skiptranslate {
+  display: none !important;
+}
+


### PR DESCRIPTION
## Summary
- replace legacy translation snippet with GTranslate float widget
- provide translation container in Layout component
- hide Google Translate banner via global CSS

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6848b803f1a48327a653a0be5c1689ab