### PR TITLE
Clean up leftover Google Translate widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,14 +20,6 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
     
-    <script>
-      window.gtranslateSettings = {
-        default_language: 'en',
-        languages: ['en', 'es', 'ar', 'pt', 'ru', 'ja', 'fr', 'de', 'vi', 'hr'],
-        wrapper_selector: '.gtranslate_wrapper'
-      };
-    </script>
-    <script src="https://cdn.gtranslate.net/widgets/latest/float.js" defer></script>
   </head>
 
   <body>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -13,7 +13,6 @@ const Layout = ({ children }: LayoutProps) => {
         {children}
       </main>
       <Footer />
-      <div className="gtranslate_wrapper" />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- remove gtranslate widget configuration from `index.html`
- drop unused gtranslate wrapper in `Layout`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6848ba9d6e048327bc8d95777d865f67