### PR TITLE
Implement Google Translate init

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,6 +8,7 @@ interface LayoutProps {
 const Layout = ({ children }: LayoutProps) => {
   return (
     <div className="min-h-screen bg-white flex flex-col">
+      <div id="google_translate_element" style={{ display: 'none' }}></div>
       <Navigation />
       <main className="flex-1 pt-16">
         {children}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -38,18 +38,16 @@ const Navigation = () => {
 
   useEffect(() => {
     const addGoogleTranslateScript = () => {
-      const script = document.createElement('script');
-      script.src = '//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
-      script.defer = true;
-      document.body.appendChild(script);
-
       window.googleTranslateElementInit = () => {
-        new window.google.translate.TranslateElement({
-          pageLanguage: 'en',
-          includedLanguages: 'en,hr,de',
-          autoDisplay: false,
-          layout: window.google.translate.TranslateElement.InlineLayout.SIMPLE
-        });
+        new window.google.translate.TranslateElement(
+          {
+            pageLanguage: 'en',
+            includedLanguages: 'en,hr,de',
+            autoDisplay: false,
+            layout: window.google.translate.TranslateElement.InlineLayout.SIMPLE,
+          },
+          'google_translate_element'
+        );
 
         // Hide default Google elements
         const css = `
@@ -69,6 +67,12 @@ const Navigation = () => {
           localStorage.setItem('conexaLangSet', '1');
         }
       };
+
+      const script = document.createElement('script');
+      script.src =
+        '//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
+      script.defer = true;
+      document.body.appendChild(script);
     };
 
     const translateTo = (lang: string) => {

--- a/src/index.css
+++ b/src/index.css
@@ -81,3 +81,7 @@
   display: none !important;
 }
 
+#google_translate_element {
+  display: none;
+}
+


### PR DESCRIPTION
## Summary
- add hidden Google Translate mount in `Layout`
- initialize TranslateElement before loading the script
- hide widget element via CSS

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6848c2a4d30c8327947dc1a0c0535146