### PR TITLE
Connect translation menu to navigation

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -13,7 +13,15 @@ import { Menu, X } from 'lucide-react';
 const Navigation = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
+  const [selectedLang, setSelectedLang] = useState('');
   const location = useLocation();
+
+  const languages = [
+    { code: 'en', label: 'English' },
+    { code: 'de', label: 'Deutsch' },
+    { code: 'fr', label: 'Français' },
+    { code: 'es', label: 'Español' },
+  ];
 
   const navItems = [
     { label: 'Features', href: '/modules' },
@@ -35,6 +43,20 @@ const Navigation = () => {
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
+
+  const translateTo = (lang: string) => {
+    const sel = document.querySelector('.goog-te-combo') as HTMLSelectElement;
+    if (sel && sel.value !== lang) {
+      sel.value = lang;
+      sel.dispatchEvent(new Event('change'));
+    }
+  };
+
+  const handleLanguageChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const lang = e.target.value;
+    setSelectedLang(lang);
+    translateTo(lang);
+  };
 
   useEffect(() => {
     const addGoogleTranslateScript = () => {
@@ -72,14 +94,6 @@ const Navigation = () => {
         '//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
       script.defer = true;
       document.body.appendChild(script);
-    };
-
-    const translateTo = (lang: string) => {
-      const sel = document.querySelector('.goog-te-combo') as HTMLSelectElement;
-      if (sel && sel.value !== lang) {
-        sel.value = lang;
-        sel.dispatchEvent(new Event('change'));
-      }
     };
 
     if (!window.google?.translate?.TranslateElement) {
@@ -122,8 +136,23 @@ const Navigation = () => {
             ))}
           </div>
 
-          {/* CTA Button */}
+          {/* Language Select & CTA Button */}
           <div className="hidden lg:flex items-center space-x-3">
+            <select
+              aria-label="Change language"
+              value={selectedLang}
+              onChange={handleLanguageChange}
+              className="border rounded px-2 py-1 text-sm"
+            >
+              <option value="" disabled>
+                Language
+              </option>
+              {languages.map((l) => (
+                <option key={l.code} value={l.code}>
+                  {l.label}
+                </option>
+              ))}
+            </select>
             <Button
               className="bg-[#FF7847] hover:bg-orange-600 font-inter text-sm transition-all hover:scale-105 shadow-sm"
               asChild
@@ -169,6 +198,21 @@ const Navigation = () => {
               ))}
 
               <div className="flex flex-col space-y-3 pt-4 border-t border-gray-100">
+                <select
+                  aria-label="Change language"
+                  value={selectedLang}
+                  onChange={handleLanguageChange}
+                  className="border rounded px-3 py-2 text-sm"
+                >
+                  <option value="" disabled>
+                    Language
+                  </option>
+                  {languages.map((l) => (
+                    <option key={l.code} value={l.code}>
+                      {l.label}
+                    </option>
+                  ))}
+                </select>
                 <Button
                   className="bg-[#FF7847] hover:bg-orange-600 font-inter text-sm h-12 w-full"
                   asChild

--- a/src/index.css
+++ b/src/index.css
@@ -76,9 +76,22 @@
   }
 }
 
-/* Hide Google Translate banner */
-.goog-te-banner-frame.skiptranslate {
+/* Hide Google Translate toolbar and elements */
+.goog-te-banner-frame.skiptranslate,
+.goog-te-gadget-icon,
+.goog-te-balloon-frame,
+.goog-te-spinner-pos,
+#goog-gt-tt,
+iframe.goog-te-banner-frame {
   display: none !important;
+}
+
+#google_translate_element {
+  display: none;
+}
+
+body {
+  top: 0 !important;
 }
 
 

--- a/translate_buttons_example.html
+++ b/translate_buttons_example.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="hr">
+<head>
+  <meta charset="UTF-8">
+  <title>Google Translate – Gumbi</title>
+  <style>
+    .goog-te-banner-frame.skiptranslate,
+    .goog-te-gadget-icon,
+    .goog-te-balloon-frame,
+    .goog-te-spinner-pos,
+    #goog-gt-tt,
+    iframe.goog-te-banner-frame {
+      display: none !important;
+    }
+
+    body {
+      top: 0 !important;
+    }
+
+    #google_translate_element {
+      display: none;
+    }
+
+    .notranslate {
+      font-weight: bold;
+      margin: 10px;
+      padding: 8px 12px;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+  <h1>Dobrodošli!</h1>
+
+  <div id="custom_translate_buttons">
+    <button class="notranslate" onclick="translateTo('en')">English</button>
+    <button class="notranslate" onclick="translateTo('de')">Deutsch</button>
+    <button class="notranslate" onclick="translateTo('fr')">Français</button>
+    <button class="notranslate" onclick="translateTo('es')">Español</button>
+  </div>
+
+  <div id="custom_translate_menu">
+    <label for="language_selector" class="notranslate">Jezik:</label>
+    <select id="language_selector" class="notranslate" onchange="translateSelect(this.value)">
+      <option value="" selected disabled>Odaberi jezik</option>
+      <option value="en">English</option>
+      <option value="de">Deutsch</option>
+      <option value="fr">Français</option>
+      <option value="es">Español</option>
+    </select>
+  </div>
+
+  <div id="google_translate_element"></div>
+
+  <script type="text/javascript">
+    function googleTranslateElementInit() {
+      new google.translate.TranslateElement({pageLanguage: 'hr'}, 'google_translate_element');
+    }
+
+    function translateSelect(lang) {
+      if (lang) {
+        translateTo(lang);
+      }
+    }
+
+    function translateTo(lang) {
+      const select = document.querySelector('.goog-te-combo');
+      if (select) {
+        select.value = lang;
+        select.dispatchEvent(new Event('change'));
+      }
+    }
+  </script>
+  <script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- hide Google Translate toolbar with global CSS
- integrate language dropdown into the Navigation component for desktop and mobile

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68494460c2c483278a06424f4e2dcfa6