### PR TITLE
chore: add newline at EOF in Navigation

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -26,3 +26,4 @@ useEffect(() => {
     return () => clearInterval(id);
   }
 }, [selectedLang]);
+export default Navigation;


### PR DESCRIPTION
## Summary
- add `export default Navigation` line with newline at end of `src/components/Navigation.tsx`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849540a7bf083278f602470b82c30c1