### PR TITLE
Remove inline Google Translate styles

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -84,10 +84,16 @@
 /* Hide Google Translate default UI */
 #google_translate_element,
 .goog-te-combo,
+.goog-logo-link,
+.goog-te-gadget span,
 .goog-te-gadget-icon,
 .goog-te-balloon-frame,
 #goog-gt-tt {
   display: none !important;
+}
+
+body {
+  top: 0 !important;
 }
 
 


### PR DESCRIPTION
## Summary
- centralize Google Translate styling

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684956a79fd48327a57a3ef59419e21e