### PR TITLE
Fix language selector loading with SES

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,10 @@ If you are developing a production application, we recommend using TypeScript wi
 
 ## Language Selector
 
-This project integrates a simple language selector powered by Google Translate. The required script is loaded on page load from `https://translate.google.com/translate_a/element.js`, enabling automatic translation of the interface.
+This project integrates a simple language selector powered by Google Translate. The widget is initialised from `index.html` using the script at `https://translate.google.com/translate_a/element.js`, enabling automatic translation of the interface.
 
 The selector is rendered above the main navigation bar as shown in [`src/components/Layout.tsx`](src/components/Layout.tsx) and offers buttons for switching between English (EN), Croatian (HR) and German (DE) as defined in [`src/components/LanguageSelector.tsx`](src/components/LanguageSelector.tsx).
 
 Translation logic is encapsulated in [`useGoogleTranslate`](src/hooks/use-google-translate.ts),
-which loads the Google Translate widget on demand and exposes a simple
-`translateTo(lang)` function used by the navigation bar.
+which exposes a simple `translateTo(lang)` function used by the navigation bar.
 

--- a/index.html
+++ b/index.html
@@ -24,9 +24,34 @@
 
   <body>
     <div id="root"></div>
+    <script>
+      function googleTranslateElementInit() {
+        new google.translate.TranslateElement(
+          {
+            pageLanguage: 'en',
+            includedLanguages: 'en,hr,de',
+            autoDisplay: false,
+            layout: google.translate.TranslateElement.InlineLayout.SIMPLE,
+          },
+          'google_translate_element'
+        );
+
+        const css = `
+          #google_translate_element, .goog-te-combo, .goog-logo-link,
+          .goog-te-gadget span, .goog-te-banner-frame,
+          .goog-te-gadget-icon, .goog-te-balloon-frame,
+          #goog-gt-tt { display:none!important }
+          body { top:0!important }
+        `;
+        const style = document.createElement('style');
+        style.innerHTML = css;
+        document.head.appendChild(style);
+      }
+    </script>
+    <script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
     <!-- IMPORTANT: DO NOT REMOVE THIS SCRIPT TAG OR THIS VERY COMMENT! -->
-  <script src="https://cdn.gpteng.co/gptengineer.js" type="module"></script>
-  <script type="module" src="/src/main.jsx"></script>
-  <script src="//code.tidio.co/fontlmte7zawbfiakj2b3a3an3uojoom.js" async></script>
+    <script src="https://cdn.gpteng.co/gptengineer.js" type="module"></script>
+    <script type="module" src="/src/main.jsx"></script>
+    <script src="//code.tidio.co/fontlmte7zawbfiakj2b3a3an3uojoom.js" async></script>
   </body>
 </html>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -38,7 +38,7 @@ const Navigation = () => {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
-  const translateTo = useGoogleTranslate('en', 'en,hr,de');
+  const translateTo = useGoogleTranslate();
 
   useEffect(() => {
     const userLang = (navigator.language || '').substring(0, 2);

--- a/src/hooks/use-google-translate.ts
+++ b/src/hooks/use-google-translate.ts
@@ -1,14 +1,15 @@
-import { useEffect } from 'react';
+// This hook assumes the Google Translate widget is already
+// loaded on the page. It simply exposes a translateTo(lang)
+// function that updates the hidden select element injected by
+// the widget. The component using this hook should ensure the
+// script has been loaded (see index.html).
 
 /**
- * Loads the Google Translate script and returns a function to translate
- * the page to the given language code. If the Google widget has not
- * loaded yet, the translation will be retried until it becomes available.
+ * Returns a function to translate the page to the given language code.
+ * If the Google widget has not loaded yet, the translation will be
+ * retried until it becomes available.
  */
-export function useGoogleTranslate(
-  pageLang = 'en',
-  languages = 'en,hr,de'
-) {
+export function useGoogleTranslate() {
   function apply(lang: string): boolean {
     const sel = document.querySelector('.goog-te-combo') as
       | HTMLSelectElement
@@ -30,39 +31,6 @@ export function useGoogleTranslate(
       }, 500);
     }
   }
-
-  useEffect(() => {
-    if ((window as any).google?.translate?.TranslateElement) return;
-
-    (window as any).googleTranslateElementInit = () => {
-      new (window as any).google.translate.TranslateElement(
-        {
-          pageLanguage: pageLang,
-          includedLanguages: languages,
-          autoDisplay: false,
-          layout: (window as any).google.translate.TranslateElement.InlineLayout.SIMPLE,
-        },
-        'google_translate_element'
-      );
-
-      const css = `
-        #google_translate_element, .goog-te-combo, .goog-logo-link,
-        .goog-te-gadget span, .goog-te-banner-frame,
-        .goog-te-gadget-icon, .goog-te-balloon-frame,
-        #goog-gt-tt { display:none!important }
-        body { top:0!important }
-      `;
-      const style = document.createElement('style');
-      style.innerHTML = css;
-      document.head.appendChild(style);
-    };
-
-    const script = document.createElement('script');
-    script.src =
-      '//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
-    script.defer = true;
-    document.body.appendChild(script);
-  }, [pageLang, languages]);
 
   return translateTo;
 }


### PR DESCRIPTION
## Summary
- load Google Translate widget upfront in `index.html` so SES lockdown doesn't block it
- simplify `useGoogleTranslate` hook to only trigger translation
- adjust `Navigation` to use updated hook
- document new loading approach

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68495e7d47388327a55d8bb867fe7e44