### PR TITLE
Implement Google Translate dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,9 +37,14 @@
         );
 
         const css = `
-          #google_translate_element, .goog-te-combo, .goog-logo-link,
-          .goog-te-gadget span, .goog-te-banner-frame,
-          .goog-te-gadget-icon, .goog-te-balloon-frame,
+          #google_translate_element {
+            position: fixed;
+            top: 8px;
+            right: 8px;
+            z-index: 1000;
+            overflow: hidden;
+          }
+          .goog-te-banner-frame,
           #goog-gt-tt { display:none!important }
           body { top:0!important }
         `;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,7 +8,6 @@ interface LayoutProps {
 const Layout = ({ children }: LayoutProps) => {
   return (
     <div className="min-h-screen bg-white flex flex-col">
-      <div id="google_translate_element"></div>
       <Navigation />
       <main className="flex-1 pt-16">
         {children}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -9,7 +9,6 @@ import { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Menu, X } from 'lucide-react';
-import LanguageSelector from './LanguageSelector';
 import { useGoogleTranslate } from '@/hooks/use-google-translate';
 
 const Navigation = () => {
@@ -57,7 +56,8 @@ const Navigation = () => {
           ? 'bg-transparent translate-y-0' 
           : 'bg-white/95 backdrop-blur-sm border-b border-gray-100 translate-y-0'
     }`}>
-      <div className="container mx-auto px-4">
+      <div className="container mx-auto px-4 relative">
+        <div id="google_translate_element"></div>
         <div className="flex items-center justify-between h-16">
           {/* Logo */}
           <Link to="/" className="flex items-center space-x-2">
@@ -99,7 +99,6 @@ const Navigation = () => {
                 Start Free Today
               </a>
             </Button>
-            <LanguageSelector onSelect={translateTo} />
           </div>
 
           {/* Mobile Menu Button */}
@@ -145,7 +144,6 @@ const Navigation = () => {
                     Start Free Today
                   </a>
                 </Button>
-                <LanguageSelector onSelect={translateTo} className="justify-center" />
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- remove custom language selector and move Google Translate element inside nav
- style translation widget with CSS so it floats in the corner and hides banner
- remove unused element from layout

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684961103ed48327b24368d2da3a9432