### PR TITLE
Show Google Translate widget

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -50,7 +50,7 @@ const Navigation = () => {
           : 'bg-white/95 backdrop-blur-sm border-b border-gray-100 translate-y-0'
     }`}>
       <div className="container mx-auto px-4 relative">
-        <div id="google_translate_element" className="sr-only" />
+        <div id="google_translate_element" className="mr-4" />
         <div className="flex items-center justify-between h-16">
           {/* Logo */}
           <Link to="/" className="flex items-center space-x-2">

--- a/src/index.css
+++ b/src/index.css
@@ -76,27 +76,6 @@
   }
 }
 
-/* Hide Google Translate banner */
-.goog-te-banner-frame.skiptranslate {
-  display: none !important;
-}
-.skiptranslate {
-  display: none !important;
-}
 
-/* Hide Google Translate default UI */
-#google_translate_element,
-.goog-te-combo,
-.goog-logo-link,
-.goog-te-gadget span,
-.goog-te-gadget-icon,
-.goog-te-balloon-frame,
-#goog-gt-tt {
-  display: none !important;
-}
-
-body {
-  top: 0 !important;
-}
 
 

--- a/translate_buttons_example.html
+++ b/translate_buttons_example.html
@@ -4,23 +4,6 @@
   <meta charset="UTF-8">
   <title>Google Translate – Gumbi</title>
   <style>
-    .goog-te-banner-frame.skiptranslate,
-    .goog-te-gadget-icon,
-    .goog-te-balloon-frame,
-    .goog-te-spinner-pos,
-    #goog-gt-tt,
-    iframe.goog-te-banner-frame {
-      display: none !important;
-    }
-
-    body {
-      top: 0 !important;
-    }
-
-    #google_translate_element {
-      display: none;
-    }
-
     .notranslate {
       font-weight: bold;
       margin: 10px;


### PR DESCRIPTION
## Summary
- remove custom styles that hid Google Translate
- display Google Translate container in the navigation bar
- update translation example to keep widget visible

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68496ad569088327a84bbb85e24ef4d2