### PR TITLE
Fix Google Translate widget visibility

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -50,7 +50,6 @@ const Navigation = () => {
           : 'bg-white/95 backdrop-blur-sm border-b border-gray-100 translate-y-0'
     }`}>
       <div className="container mx-auto px-4 relative">
-        <div id="google_translate_element" className="sr-only" />
         <div className="flex items-center justify-between h-16">
           {/* Logo */}
           <Link to="/" className="flex items-center space-x-2">
@@ -93,6 +92,7 @@ const Navigation = () => {
               </a>
             </Button>
           </div>
+          <div id="google_translate_element" className="ml-4" />
 
           {/* Mobile Menu Button */}
           <button

--- a/src/hooks/use-google-translate.ts
+++ b/src/hooks/use-google-translate.ts
@@ -3,7 +3,8 @@ import { useCallback, useEffect } from 'react';
 export const useGoogleTranslate = () => {
   // inject Google Translate script on mount
   useEffect(() => {
-    if (window.google) return;
+    const hasTranslate = !!window.google?.translate?.TranslateElement;
+    if (hasTranslate) return;
 
     window.googleTranslateElementInit = () => {
       if (!window.google) return;

--- a/src/index.css
+++ b/src/index.css
@@ -76,27 +76,6 @@
   }
 }
 
-/* Hide Google Translate banner */
-.goog-te-banner-frame.skiptranslate {
-  display: none !important;
-}
-.skiptranslate {
-  display: none !important;
-}
 
-/* Hide Google Translate default UI */
-#google_translate_element,
-.goog-te-combo,
-.goog-logo-link,
-.goog-te-gadget span,
-.goog-te-gadget-icon,
-.goog-te-balloon-frame,
-#goog-gt-tt {
-  display: none !important;
-}
-
-body {
-  top: 0 !important;
-}
 
 

--- a/translate_buttons_example.html
+++ b/translate_buttons_example.html
@@ -4,23 +4,6 @@
   <meta charset="UTF-8">
   <title>Google Translate – Gumbi</title>
   <style>
-    .goog-te-banner-frame.skiptranslate,
-    .goog-te-gadget-icon,
-    .goog-te-balloon-frame,
-    .goog-te-spinner-pos,
-    #goog-gt-tt,
-    iframe.goog-te-banner-frame {
-      display: none !important;
-    }
-
-    body {
-      top: 0 !important;
-    }
-
-    #google_translate_element {
-      display: none;
-    }
-
     .notranslate {
       font-weight: bold;
       margin: 10px;


### PR DESCRIPTION
## Summary
- move Google Translate div inside the nav bar
- check for TranslateElement before injecting script so other Google scripts don't block loading

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68496ad569088327a84bbb85e24ef4d2