### PR TITLE
Fix Google translate hook

### DIFF
--- a/src/hooks/use-google-translate.ts
+++ b/src/hooks/use-google-translate.ts
@@ -4,7 +4,7 @@ export const useGoogleTranslate = () => {
   // inject Google Translate script on mount
   useEffect(() => {
 
-
+    const initTranslate = () => {
       new window.google.translate.TranslateElement(
         {
           pageLanguage: 'en',


### PR DESCRIPTION
## Summary
- fix missing `initTranslate` definition so the Google Translate widget inits properly

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849721f17708327acdf50be0e772817