### PR TITLE
Fix Google translate hook

### DIFF
--- a/src/hooks/use-google-translate.ts
+++ b/src/hooks/use-google-translate.ts
@@ -4,6 +4,12 @@ export const useGoogleTranslate = () => {
   // inject Google Translate script on mount
   useEffect(() => {
 
+    const initTranslate = () => {
+      if (!window.google?.translate?.TranslateElement) return;
+      const combo = document.querySelector(
+        '#google_translate_element select.goog-te-combo'
+      );
+      if (combo) return; // already initialized
 
       new window.google.translate.TranslateElement(
         {


### PR DESCRIPTION
## Summary
- prevent duplicate widget initialization so Google Translate no longer disappears

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849721f17708327acdf50be0e772817