### PR TITLE
Add visible Google Translate selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,6 @@ This project integrates a simple language selector powered by Google Translate. 
 The selector is rendered above the main navigation bar as shown in [`src/components/Layout.tsx`](src/components/Layout.tsx) and offers buttons for switching between English (EN), Croatian (HR) and German (DE) as defined in [`src/components/LanguageSelector.tsx`](src/components/LanguageSelector.tsx).
 
 Translation logic is encapsulated in [`useGoogleTranslate`](src/hooks/use-google-translate.ts),
-which exposes a simple `translateTo(lang)` function used by the navigation bar.
+which exposes a simple `translateTo(lang)` function used by `Layout` to initialise
+the Google widget and apply the chosen language.
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,13 +1,31 @@
 import Navigation from './Navigation';
 import Footer from './Footer';
+import LanguageSelector from './LanguageSelector';
+import { useGoogleTranslate } from '@/hooks/use-google-translate';
+import { useEffect } from 'react';
 
 interface LayoutProps {
   children: React.ReactNode;
 }
 
 const Layout = ({ children }: LayoutProps) => {
+  const translateTo = useGoogleTranslate();
+
+  useEffect(() => {
+    const userLang = (navigator.language || '').substring(0, 2);
+    const first = !localStorage.getItem('conexaLangSet');
+    if (first && ['hr', 'en', 'de'].includes(userLang)) {
+      translateTo(userLang);
+      localStorage.setItem('conexaLangSet', '1');
+    }
+  }, [translateTo]);
+
   return (
     <div className="min-h-screen bg-white flex flex-col">
+      <div className="self-end p-2">
+        <LanguageSelector onSelect={translateTo} />
+        <div id="google_translate_element" className="mt-2" />
+      </div>
       <Navigation />
       <main className="flex-1 pt-16">
         {children}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Menu, X } from 'lucide-react';
-import { useGoogleTranslate } from '@/hooks/use-google-translate';
 
 const Navigation = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
@@ -29,17 +28,6 @@ const Navigation = () => {
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
-
-  const translateTo = useGoogleTranslate();
-
-  useEffect(() => {
-    const userLang = (navigator.language || '').substring(0, 2);
-    const first = !localStorage.getItem('conexaLangSet');
-    if (first && ['hr', 'en', 'de'].includes(userLang)) {
-      translateTo(userLang);
-      localStorage.setItem('conexaLangSet', '1');
-    }
-  }, [translateTo]);
 
   return (
     <nav className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
@@ -92,7 +80,6 @@ const Navigation = () => {
               </a>
             </Button>
           </div>
-          <div id="google_translate_element" className="ml-4" />
 
           {/* Mobile Menu Button */}
           <button


### PR DESCRIPTION
## Summary
- provide `useGoogleTranslate` hook from `Layout` and add `LanguageSelector`
- remove Google Translate logic from `Navigation`
- document new translation logic in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684976a50e788327a5429b51f3b23959