### PR TITLE
Fix build by dropping old language selector

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,31 +1,16 @@
 import Navigation from './Navigation';
 import Footer from './Footer';
 import GoogleTranslateWidget from './GoogleTranslateWidget';
-import LanguageSelector from './LanguageSelector';
-import { useGoogleTranslate } from '@/hooks/use-google-translate';
-import { useEffect } from 'react';
 
 interface LayoutProps {
   children: React.ReactNode;
 }
 
 const Layout = ({ children }: LayoutProps) => {
-  const translateTo = useGoogleTranslate();
-
-  useEffect(() => {
-    const userLang = (navigator.language || '').substring(0, 2);
-    const first = !localStorage.getItem('conexaLangSet');
-    if (first && ['hr', 'en', 'de'].includes(userLang)) {
-      translateTo(userLang);
-      localStorage.setItem('conexaLangSet', '1');
-    }
-  }, [translateTo]);
 
   return (
     <div className="min-h-screen bg-white flex flex-col">
       <div className="self-end p-2">
-        <LanguageSelector onSelect={translateTo} />
-        <div id="google_translate_element" className="mt-2" />
         <GoogleTranslateWidget />
       </div>
       <Navigation />


### PR DESCRIPTION
## Summary
- remove outdated `LanguageSelector` and hook usage from `Layout`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849a45a5c24832798b325fad78b5dc9