### PR TITLE
Add language switcher dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ If you are developing a production application, we recommend using TypeScript wi
 
 ## Google Translate
 
-The application now displays the default Google Translate widget, loaded via the
-`GoogleTranslateWidget` component. The widget is initialised dynamically with the
-script `https://translate.google.com/translate_a/element.js` and supports English
-(EN), Croatian (HR) and German (DE).
+The application displays the default Google Translate widget via the
+`GoogleTranslateWidget` component. A custom `LanguageSwitcher` dropdown is also
+provided to trigger the language change. The widget is initialised dynamically
+with the script `https://translate.google.com/translate_a/element.js` and
+supports English (EN), Croatian (HR) and German (DE).
 
 

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+const languages = [
+  { code: 'en', label: 'English' },
+  { code: 'hr', label: 'Hrvatski' },
+  { code: 'de', label: 'Deutsch' },
+];
+
+const LanguageSwitcher = () => {
+  const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const lang = event.target.value;
+    const select = document.querySelector<HTMLSelectElement>('.goog-te-combo');
+    if (select) {
+      select.value = lang;
+      select.dispatchEvent(new Event('change'));
+    }
+  };
+
+  return (
+    <select onChange={handleChange} className="border rounded p-1 text-sm">
+      {languages.map(({ code, label }) => (
+        <option key={code} value={code}>
+          {label}
+        </option>
+      ))}
+    </select>
+  );
+};
+
+export default LanguageSwitcher;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import Navigation from './Navigation';
 import Footer from './Footer';
 import GoogleTranslateWidget from './GoogleTranslateWidget';
+import LanguageSwitcher from './LanguageSwitcher';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -10,7 +11,8 @@ const Layout = ({ children }: LayoutProps) => {
 
   return (
     <div className="min-h-screen bg-white flex flex-col">
-      <div className="self-end p-2">
+      <div className="self-end p-2 flex gap-2 items-center">
+        <LanguageSwitcher />
         <GoogleTranslateWidget />
       </div>
       <Navigation />


### PR DESCRIPTION
## Summary
- add `LanguageSwitcher` component to manually trigger Google Translate
- include the new dropdown in the layout
- document the updated widget setup

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849a62698408327b2636dee84954300