### PR TITLE
Fix language menu overlap

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -11,7 +11,7 @@ const Layout = ({ children }: LayoutProps) => {
 
   return (
     <div className="min-h-screen bg-white flex flex-col">
-      <div className="self-end p-2 flex gap-2 items-center">
+      <div className="self-end p-2 flex gap-2 items-center relative z-[60]">
         <LanguageSwitcher />
         <GoogleTranslateWidget />
       </div>


### PR DESCRIPTION
## Summary
- ensure language dropdown appears above fixed navigation

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849a781988c832790009a0ee2705d46