### PR TITLE
Enable Google Translate with more languages

### DIFF
--- a/src/components/GoogleTranslateWidget.tsx
+++ b/src/components/GoogleTranslateWidget.tsx
@@ -8,7 +8,7 @@ const GoogleTranslateWidget = () => {
       new window.google.translate.TranslateElement(
         {
           pageLanguage: 'en',
-          includedLanguages: 'en,hr,de',
+          includedLanguages: 'en,hr,de,es,fr,pt,nl,ru,ja,ar',
           autoDisplay: false,
           layout: window.google.translate.TranslateElement.InlineLayout.SIMPLE,
         },

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -4,6 +4,13 @@ const languages = [
   { code: 'en', label: 'English' },
   { code: 'hr', label: 'Hrvatski' },
   { code: 'de', label: 'Deutsch' },
+  { code: 'es', label: 'Español' },
+  { code: 'fr', label: 'Français' },
+  { code: 'pt', label: 'Português' },
+  { code: 'nl', label: 'Nederlands' },
+  { code: 'ru', label: 'Русский' },
+  { code: 'ja', label: '日本語' },
+  { code: 'ar', label: 'العربية' },
 ];
 
 const LanguageSwitcher = () => {

--- a/src/index.css
+++ b/src/index.css
@@ -71,9 +71,24 @@
     @apply border-border;
   }
 
-  body {
-    @apply bg-background text-foreground;
-  }
+body {
+  @apply bg-background text-foreground;
+}
+}
+
+/* Google Translate banner overrides */
+.goog-te-banner-frame.skiptranslate {
+  display: none !important;
+}
+body {
+  top: 0 !important;
+}
+.goog-logo-link {
+  display: none !important;
+}
+.goog-te-gadget-simple {
+  border: none !important;
+  padding: 0 !important;
 }
 
 


### PR DESCRIPTION
## Summary
- expand the languages supported in `GoogleTranslateWidget`
- update `LanguageSwitcher` to list the same languages
- hide Google Translate banner via global CSS

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849ab948e1083278f8882b2abe4dc94