### PR TITLE
Embed Google Translate widget in iframe

### DIFF
--- a/public/translator.html
+++ b/public/translator.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <style>
+      body { margin: 0; }
+    </style>
+  </head>
+  <body>
+    <div id="google_translate_element"></div>
+    <script>
+      function googleTranslateElementInit() {
+        new google.translate.TranslateElement(
+          {
+            pageLanguage: 'en',
+            includedLanguages: 'en,hr,de,es,fr,pt,nl,ru,ja,ar',
+            autoDisplay: false,
+            layout: google.translate.TranslateElement.InlineLayout.SIMPLE,
+          },
+          'google_translate_element'
+        );
+      }
+    </script>
+    <script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+  </body>
+</html>

--- a/src/components/GoogleTranslateWidget.tsx
+++ b/src/components/GoogleTranslateWidget.tsx
@@ -1,30 +1,12 @@
-import { useEffect } from 'react';
-
 const GoogleTranslateWidget = () => {
-  useEffect(() => {
-    if (document.getElementById('google-translate-script')) return;
-
-    window.googleTranslateElementInit = () => {
-      new window.google.translate.TranslateElement(
-        {
-          pageLanguage: 'en',
-          includedLanguages: 'en,hr,de,es,fr,pt,nl,ru,ja,ar',
-          autoDisplay: false,
-          layout: window.google.translate.TranslateElement.InlineLayout.SIMPLE,
-        },
-        'google_translate_element'
-      );
-    };
-
-    const script = document.createElement('script');
-    script.id = 'google-translate-script';
-    script.src =
-      '//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
-    script.async = true;
-    document.body.appendChild(script);
-  }, []);
-
-  return <div id="google_translate_element" className="mt-2" />;
+  return (
+    <iframe
+      src="/translator.html"
+      title="Google Translate"
+      className="mt-2 border-0"
+      style={{ height: '40px', width: '150px' }}
+    />
+  );
 };
 
 export default GoogleTranslateWidget;


### PR DESCRIPTION
## Summary
- add a `public/translator.html` page with Google Translate script
- load the widget via an `<iframe>` in `GoogleTranslateWidget`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6849adbb12348327a3e8b8f763716e08