### PR TITLE
Implement custom Google Translate dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,12 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+
+    <style>
+      .goog-te-banner-frame { display: none !important; }
+      .goog-logo-link { display: none !important; }
+      body { top: 0 !important; }
+    </style>
     
   </head>
 

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect } from 'react';
+
+declare global {
+  interface Window {
+    googleTranslateElementInit?: () => void;
+    google?: any;
+  }
+}
+
+const LanguageSelector: React.FC = () => {
+  useEffect(() => {
+    if (document.getElementById('google-translate-script')) return;
+    const script = document.createElement('script');
+    script.id = 'google-translate-script';
+    script.src =
+      '//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
+    document.body.appendChild(script);
+    window.googleTranslateElementInit = () => {
+      new window.google.translate.TranslateElement(
+        {
+          pageLanguage: 'en',
+          includedLanguages: 'en,hr,de,es,fr,pt,nl,ru,ja,ar',
+          layout: window.google.translate.TranslateElement.InlineLayout.SIMPLE,
+        },
+        'google_translate_element'
+      );
+    };
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const lang = e.target.value;
+    const combo = document.querySelector<HTMLSelectElement>('.goog-te-combo');
+    if (combo) {
+      combo.value = lang;
+      combo.dispatchEvent(new Event('change'));
+    }
+  };
+
+  return (
+    <>
+      <div id="google_translate_element" style={{ display: 'none' }} />
+      <select onChange={handleChange} defaultValue="en">
+        <option value="en">English</option>
+        <option value="hr">Hrvatski</option>
+        <option value="de">Deutsch</option>
+        <option value="es">Español</option>
+        <option value="fr">Français</option>
+        <option value="pt">Português</option>
+        <option value="nl">Nederlands</option>
+        <option value="ru">Русский</option>
+        <option value="ja">日本語</option>
+        <option value="ar">العربية</option>
+      </select>
+    </>
+  );
+};
+
+export default LanguageSelector;


### PR DESCRIPTION
## Summary
- add LanguageSelector component for Google Translate inline usage
- hide Google banner and attribution in index.html

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6849b43750d88327b2eb5509fa8bfb46