### PR TITLE
Implement custom Google Translate dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,15 +21,17 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
 
     <style>
-      .goog-te-banner-frame { display: none !important; }
-      .goog-logo-link { display: none !important; }
+      .goog-te-banner-frame.skiptranslate { display: none !important; }
       body { top: 0 !important; }
+      .goog-logo-link { display: none !important; }
+      .goog-te-gadget-simple { border: none !important; padding: 0 !important; }
     </style>
     
   </head>
 
   <body>
     <div id="root"></div>
+    <script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
     <!-- Google Translate is injected dynamically -->
     <!-- IMPORTANT: DO NOT REMOVE THIS SCRIPT TAG OR THIS VERY COMMENT! -->
     <script src="https://cdn.gpteng.co/gptengineer.js" type="module"></script>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,7 +1,6 @@
 import Navigation from './Navigation';
 import Footer from './Footer';
-import GoogleTranslateWidget from './GoogleTranslateWidget';
-import LanguageSwitcher from './LanguageSwitcher';
+import LanguageSelector from './LanguageSelector';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -12,8 +11,7 @@ const Layout = ({ children }: LayoutProps) => {
   return (
     <div className="min-h-screen bg-white flex flex-col">
       <div className="self-end p-2 flex gap-2 items-center relative z-[60]">
-        <LanguageSwitcher />
-        <GoogleTranslateWidget />
+        <LanguageSelector />
       </div>
       <Navigation />
       <main className="flex-1 pt-16">


### PR DESCRIPTION
## Summary
- add CSS rules in index.html to hide Google toolbar/banner
- load Google translate script in index.html
- replace previous translation widget in Layout with LanguageSelector

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849b8b834b88327bc8156834acdd57a