### PR TITLE
Fix language selector and link nesting

### DIFF
--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,15 +1,28 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 const LanguageSelector: React.FC = () => {
   const { i18n } = useTranslation();
 
+  useEffect(() => {
+    const stored = localStorage.getItem('lang');
+    if (stored && stored !== i18n.language) {
+      i18n.changeLanguage(stored);
+    }
+  }, [i18n]);
+
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    i18n.changeLanguage(e.target.value);
+    const lang = e.target.value;
+    i18n.changeLanguage(lang);
+    localStorage.setItem('lang', lang);
   };
 
   return (
-    <select onChange={handleChange} defaultValue={i18n.language} className="border rounded p-1 text-sm">
+    <select
+      onChange={handleChange}
+      value={i18n.language}
+      className="border border-gray-300 rounded-md p-2 text-sm bg-white text-gray-700"
+    >
       <option value="en">English</option>
       <option value="hr">Hrvatski</option>
     </select>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,6 +1,5 @@
 import Navigation from './Navigation';
 import Footer from './Footer';
-import LanguageSelector from './LanguageSelector';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -10,9 +9,6 @@ const Layout = ({ children }: LayoutProps) => {
 
   return (
     <div className="min-h-screen bg-white flex flex-col">
-      <div className="self-end p-2 flex gap-2 items-center relative z-[60]">
-        <LanguageSelector />
-      </div>
       <Navigation />
       <main className="flex-1 pt-16">
         {children}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Menu, X } from 'lucide-react';
+import LanguageSelector from './LanguageSelector';
 
 const Navigation = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
@@ -66,6 +67,7 @@ const Navigation = () => {
 
           {/* CTA Button */}
           <div className="hidden lg:flex items-center space-x-3">
+            <LanguageSelector />
             <Button
               className="bg-[#FF7847] hover:bg-orange-600 font-inter text-sm transition-all hover:scale-105 shadow-sm"
               asChild
@@ -111,6 +113,7 @@ const Navigation = () => {
               ))}
 
               <div className="flex flex-col space-y-3 pt-4 border-t border-gray-100">
+                <LanguageSelector />
                 <Button
                   className="bg-[#FF7847] hover:bg-orange-600 font-inter text-sm h-12 w-full"
                   asChild

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,13 +2,16 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
-import './i18n';
+import i18n from './i18n';
+import { I18nextProvider } from 'react-i18next';
 import '@fontsource/inter';
 import '@fontsource/poppins';
 
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <I18nextProvider i18n={i18n}>
+      <App />
+    </I18nextProvider>
   </StrictMode>,
 )

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -94,30 +94,30 @@ const Index = () => {
         <section className="py-6 bg-white border-b border-gray-100">
           <div className="container mx-auto px-4">
             <div className="text-center">
-              <a
-                href="https://www.youtube.com/shorts/82Nsgn200iM"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center justify-center gap-3 text-conexa-primary hover:text-blue-700 transition-colors"
-              >
-                <Play className="w-8 h-8" />
-                <div className="flex flex-col items-center">
+              <div className="inline-flex flex-col items-center gap-2 text-conexa-primary">
+                <a
+                  href="https://www.youtube.com/shorts/82Nsgn200iM"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center justify-center gap-3 hover:text-blue-700 transition-colors"
+                >
+                  <Play className="w-8 h-8" />
                   <span className="font-poppins font-semibold text-xl md:text-2xl">
                     {t("index.socialProof.video")}
                   </span>
-                  <a
-                    href="https://www.youtube.com/watch?v=K-08rgQU75U&feature=youtu.be"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center justify-center gap-2 text-orange-500 hover:text-orange-700 mt-2 transition-colors"
-                  >
-                    <Megaphone className="w-5 h-5" />
-                    <span className="font-inter font-medium text-base">
-                      {t("index.socialProof.podcast")}
-                    </span>
-                  </a>
-                </div>
-              </a>
+                </a>
+                <a
+                  href="https://www.youtube.com/watch?v=K-08rgQU75U&feature=youtu.be"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center justify-center gap-2 text-orange-500 hover:text-orange-700 transition-colors"
+                >
+                  <Megaphone className="w-5 h-5" />
+                  <span className="font-inter font-medium text-base">
+                    {t("index.socialProof.podcast")}
+                  </span>
+                </a>
+              </div>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- move language selector into Navigation and style it
- persist language choice via localStorage
- add i18n provider
- fix nested anchor on the index page

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849cccf1d2c832785241741fb67fd83