### PR TITLE
refactor module titles to use translation keys

### DIFF
--- a/src/components/ModuleNav.tsx
+++ b/src/components/ModuleNav.tsx
@@ -1,12 +1,14 @@
 import { Link } from 'react-router-dom';
 import { ChevronsLeft, ChevronsRight } from 'lucide-react';
 import { modulesList } from '@/lib/modules';
+import { useTranslation } from 'react-i18next';
 
 interface ModuleNavProps {
   currentId: string;
 }
 
 export default function ModuleNav({ currentId }: ModuleNavProps) {
+  const { t } = useTranslation();
   const index = modulesList.findIndex((m) => m.id === currentId);
   if (index === -1) return null;
 
@@ -21,13 +23,13 @@ export default function ModuleNav({ currentId }: ModuleNavProps) {
           className="flex items-center space-x-2 font-poppins font-semibold text-gray-700"
         >
           <ChevronsLeft size={32} strokeWidth={3} />
-          <span>{prevModule.title}</span>
+          <span>{t(prevModule.titleKey)}</span>
         </Link>
         <Link
           to={nextModule.path}
           className="flex items-center space-x-2 font-poppins font-semibold text-gray-700"
         >
-          <span>{nextModule.title}</span>
+          <span>{t(nextModule.titleKey)}</span>
           <ChevronsRight size={32} strokeWidth={3} />
         </Link>
       </div>

--- a/src/lib/modules.ts
+++ b/src/lib/modules.ts
@@ -1,30 +1,30 @@
-import i18n from '../i18n'; // Pretpostavljamo da je putanja do vaše i18n instance ovakva
-// Prilagodite putanju iznad prema vašoj strukturi projekta.
-// Ovo se koristi za prevođenje stringova izvan React komponenti (npr. u običnim JS/TS datotekama).
+// List of all available modules within the application. Only translation keys
+// are stored here so that components can translate titles at render time.
 
 export interface ModuleInfo {
   id: string;
-  title: string;
+  /** i18next translation key for the module title */
+  titleKey: string;
   path: string;
   color: string;
 }
 
 export const modulesList: ModuleInfo[] = [
-  { id: 'alarm', title: i18n.t('modulesList.alarm.title', 'Alarm'), path: '/modules/alarm', color: '#fbc02d' },
-  { id: 'bulletin-board', title: i18n.t('modulesList.bulletinBoard.title', 'Bulletin Board'), path: '/modules/bulletin-board', color: '#fdc107' },
-  { id: 'chat-room', title: i18n.t('modulesList.chatRoom.title', 'Chat Room'), path: '/modules/chat-room', color: '#4baf4f' },
-  { id: 'documents', title: i18n.t('modulesList.documents.title', 'Documents'), path: '/modules/documents', color: '#fe9100' },
-  { id: 'home-repairs', title: i18n.t('modulesList.homeRepairs.title', 'Home Repairs'), path: '/modules/home-repairs', color: '#f3372b' },
-  { id: 'local-posts', title: i18n.t('modulesList.localPosts.title', 'Local Posts'), path: '/modules/local-posts', color: '#9c27b0' },
-  { id: 'marketplace', title: i18n.t('modulesList.marketplace.title', 'Marketplace'), path: '/modules/marketplace', color: '#4caf50' },
-  { id: 'noise-alerts', title: i18n.t('modulesList.noiseAlerts.title', 'Noise Alerts'), path: '/modules/noise-alerts', color: '#e91e63' },
-  { id: 'official-notices', title: i18n.t('modulesList.officialNotices.title', 'Official Notices'), path: '/modules/official-notices', color: '#3f51b5' },
-  { id: 'parking-sharing', title: i18n.t('modulesList.parkingSharing.title', 'Parking Sharing'), path: '/modules/parking-sharing', color: '#795548' },
-  { id: 'quiz', title: i18n.t('modulesList.quiz.title', 'Quiz'), path: '/modules/quiz', color: '#009688' },
-  { id: 'security', title: i18n.t('modulesList.security.title', 'Security'), path: '/modules/security', color: '#607d8b' },
-  { id: 'shared-rides', title: i18n.t('modulesList.sharedRides.title', 'Ride Sharing'), path: '/modules/shared-rides', color: '#86be41' },
-  { id: 'shared-tasks', title: i18n.t('modulesList.sharedTasks.title', 'Shared Tasks'), path: '/modules/shared-tasks', color: '#8bc34a' },
-  { id: 'wise-owl', title: i18n.t('modulesList.wiseOwl.title', 'Wise Owl'), path: '/modules/wise-owl', color: '#ffc107' },
-  { id: 'business-networking', title: i18n.t('modulesList.businessNetworking.title', 'Business Networking'), path: '/modules/business-networking', color: '#3f51b5' },
-  { id: 'conference-rooms', title: i18n.t('modulesList.conferenceRooms.title', 'Conference Rooms'), path: '/modules/conference-rooms', color: '#9c27b0' },
+  { id: 'alarm', titleKey: 'modulesList.alarm.title', path: '/modules/alarm', color: '#fbc02d' },
+  { id: 'bulletin-board', titleKey: 'modulesList.bulletinBoard.title', path: '/modules/bulletin-board', color: '#fdc107' },
+  { id: 'chat-room', titleKey: 'modulesList.chatRoom.title', path: '/modules/chat-room', color: '#4baf4f' },
+  { id: 'documents', titleKey: 'modulesList.documents.title', path: '/modules/documents', color: '#fe9100' },
+  { id: 'home-repairs', titleKey: 'modulesList.homeRepairs.title', path: '/modules/home-repairs', color: '#f3372b' },
+  { id: 'local-posts', titleKey: 'modulesList.localPosts.title', path: '/modules/local-posts', color: '#9c27b0' },
+  { id: 'marketplace', titleKey: 'modulesList.marketplace.title', path: '/modules/marketplace', color: '#4caf50' },
+  { id: 'noise-alerts', titleKey: 'modulesList.noiseAlerts.title', path: '/modules/noise-alerts', color: '#e91e63' },
+  { id: 'official-notices', titleKey: 'modulesList.officialNotices.title', path: '/modules/official-notices', color: '#3f51b5' },
+  { id: 'parking-sharing', titleKey: 'modulesList.parkingSharing.title', path: '/modules/parking-sharing', color: '#795548' },
+  { id: 'quiz', titleKey: 'modulesList.quiz.title', path: '/modules/quiz', color: '#009688' },
+  { id: 'security', titleKey: 'modulesList.security.title', path: '/modules/security', color: '#607d8b' },
+  { id: 'shared-rides', titleKey: 'modulesList.sharedRides.title', path: '/modules/shared-rides', color: '#86be41' },
+  { id: 'shared-tasks', titleKey: 'modulesList.sharedTasks.title', path: '/modules/shared-tasks', color: '#8bc34a' },
+  { id: 'wise-owl', titleKey: 'modulesList.wiseOwl.title', path: '/modules/wise-owl', color: '#ffc107' },
+  { id: 'business-networking', titleKey: 'modulesList.businessNetworking.title', path: '/modules/business-networking', color: '#3f51b5' },
+  { id: 'conference-rooms', titleKey: 'modulesList.conferenceRooms.title', path: '/modules/conference-rooms', color: '#9c27b0' },
 ];

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,4 +1,3 @@
-
 {
   "index": {
     "banner": {
@@ -75,5 +74,24 @@
       "isoCertified": "ISO 27001 Certified",
       "gdpr": "GDPR Compliant"
     }
+  },
+  "modulesList": {
+    "alarm.title": "Alarm",
+    "bulletinBoard.title": "Bulletin Board",
+    "chatRoom.title": "Chat Room",
+    "documents.title": "Documents",
+    "homeRepairs.title": "Home Repairs",
+    "localPosts.title": "Local Posts",
+    "marketplace.title": "Marketplace",
+    "noiseAlerts.title": "Noise Alerts",
+    "officialNotices.title": "Official Notices",
+    "parkingSharing.title": "Parking Sharing",
+    "quiz.title": "Quiz",
+    "security.title": "Security",
+    "sharedRides.title": "Ride Sharing",
+    "sharedTasks.title": "Shared Tasks",
+    "wiseOwl.title": "Wise Owl",
+    "businessNetworking.title": "Business Networking",
+    "conferenceRooms.title": "Conference Rooms"
   }
 }


### PR DESCRIPTION
## Summary
- store translation keys for module titles instead of translated strings
- update `ModuleNav` to translate titles using `useTranslation`
- provide English translations for every module title

## Testing
- `npm run lint` *(fails: Parsing error: 'import' and 'export' may appear only with 'sourceType: module')*

------
https://chatgpt.com/codex/tasks/task_e_684b39a00fd8832788b098c9a7e2c614